### PR TITLE
2020-06-01: Highlight the currently visible heading in Table Of Content plugin

### DIFF
--- a/wp-content/themes/foxy-illdy/functions.php
+++ b/wp-content/themes/foxy-illdy/functions.php
@@ -6,6 +6,10 @@ add_action( 'wp_enqueue_scripts', 'my_theme_enqueue_styles' );
 function my_theme_enqueue_styles() {
     wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );
     wp_enqueue_style( 'bootstrap', get_stylesheet_directory_uri() . '/layout/css/bootstrap.min-modified.css', array(), '3.3.6-fixed', 'all' );
+
+    if( class_exists( 'lwptocAutoloader' ) ){
+        wp_enqueue_script( 'toc-highlight', get_stylesheet_directory_uri() . '/layout/js/tableOfContentActiveScroll.js', array( 'jquery' ), '1.0', true );
+    }
 }
 
 /**

--- a/wp-content/themes/foxy-illdy/layout/js/tableOfContentActiveScroll.js
+++ b/wp-content/themes/foxy-illdy/layout/js/tableOfContentActiveScroll.js
@@ -1,0 +1,59 @@
+$ = jQuery;
+$( document ).ready( function(){
+	if( $( "div.widget_lpwtoc_widget" ).length ){
+		// Function to set the headingObject easily by index
+		var getHeadingObj = function( index ){
+			return ( ( index < 0 )
+					? { offset: 0 }
+					: { index: index, offset: headerArray[ index ].offset } );
+		}
+
+		// To avoid incorrect behaviour, some offset was defined to work nicely with a sticky header on top of page
+		var PREVIOUS_SCROLL_OFFSET = 150;
+
+		// Construct the header Array
+		var headerArray = new Array();
+		$(":header span").each( function(){ headerArray.push( { offset: $( this).offset().top - PREVIOUS_SCROLL_OFFSET, ref: this.id } ); } );
+
+		// Initiate the headings
+		var prevHeading;
+		var currHeading;
+		var nextHeading = getHeadingObj( 0 );
+
+		var lastScrollPos = 0;
+
+		$(window).scroll(function(){
+			let scrollPos = $(window).scrollTop();
+			
+			// Scrolling down, check next heading - as long as this is not the last
+			if( scrollPos > lastScrollPos && nextHeading && scrollPos >= nextHeading.offset ){
+				// shift all objects
+				prevHeading = currHeading;
+				currHeading = nextHeading;
+
+				// set next heading, when current is not the last one
+				let nextHeadingIndex = ( !currHeading || currHeading.index == headerArray.length - 1 ) ? undefined : currHeading.index + 1;
+				nextHeading = ( nextHeadingIndex ) ? getHeadingObj( nextHeadingIndex ) : undefined;
+
+			} else if( scrollPos < lastScrollPos && currHeading && scrollPos <= currHeading.offset ){
+				// Scrolling up, check previous heading - as long as the current is not the first;
+				nextHeading = currHeading;
+				currHeading = prevHeading;
+				
+				// set next heading, when current is not the last one
+				let prevHeadingIndex = ( !currHeading || currHeading.index == 0 ) ? undefined : currHeading.index - 1;
+				prevHeading = ( prevHeadingIndex ) ? getHeadingObj( prevHeadingIndex ) : undefined;
+			
+			}
+			
+			// update select class
+			$( ".lwptoc_item a" ).removeClass( 'activeScroll' );
+			if( currHeading != undefined && currHeading.index >= 0 ){
+				$(".lwptoc_item a[href='#"+ headerArray[ currHeading.index ].ref +"']").addClass( 'activeScroll' );
+			}
+			
+			// update lastScrollPos to allow a bit better performance (not fetching next and prev heading)
+			lastScrollPos = scrollPos;
+		});
+	}
+});

--- a/wp-content/themes/foxy-illdy/style.css
+++ b/wp-content/themes/foxy-illdy/style.css
@@ -163,6 +163,33 @@ ol li::before{
 }
 
 /**
+ * Table of content Widget
+ */
+.widget_lpwtoc_widget{
+	width:				auto !important;
+}
+
+.lwptoc_i{
+	padding:			0 !important;
+}
+
+.lwptoc_header{
+	font-family: 		"Poppins" !important;
+	font-size: 			2rem !important;
+    color: 				var( --gray-color ) !important;
+    margin: 			0 !important;
+    padding: 			0 !important;
+}
+
+.lwptoc_item a.activeScroll{
+	font-weight:		bold;
+}
+
+.lwptoc_item a span{
+	color:				var( --primary-color ) !important;
+}
+
+/**
  * Blog Post Meta Custom widget styling
  */
 .blog-post-meta div .fa {

--- a/wp-content/themes/foxy-illdy/template-parts/content-single.php
+++ b/wp-content/themes/foxy-illdy/template-parts/content-single.php
@@ -7,7 +7,6 @@
  */
 
 $jumbotron_single_image  = get_theme_mod( 'illdy_jumbotron_enable_featured_image', true );
-
 ?>
 <article id="post-<?php the_ID(); ?>" <?php post_class( 'blog-post' ); ?>>
 	<?php if ( has_post_thumbnail() && true != $jumbotron_single_image ) { ?>


### PR DESCRIPTION
* Javascript library to highlight the actively watch heading
* functions.php: Enqueuing JS library
* style.css: CSS to have headings match rest of widget headings, remove padding and set activeScroll highlight