### PR TITLE
2020-06-01: Set Lucky WP Table of Content to set H5

### DIFF
--- a/wp-content/themes/foxy-illdy/functions.php
+++ b/wp-content/themes/foxy-illdy/functions.php
@@ -17,6 +17,11 @@ function my_theme_enqueue_styles() {
  */
 set_theme_mod( 'illdy_enable_related_blog_posts', false );
 
+/**
+ * Update Lucky WP Table Of Content plugin to set <h5> as title, instead of <span><b>
+ */
+add_filter( 'lwptoc_title_tag', function(){ return 'h5'; } );
+
 
 /**
  * CUSTOM WIDGETS

--- a/wp-content/themes/foxy-illdy/style.css
+++ b/wp-content/themes/foxy-illdy/style.css
@@ -149,7 +149,8 @@ ol li::before{
 	margin-bottom:		5rem;
 }
 
-.widget .widget-title{
+.widget .widget-title,
+.widget .lwptoc_header{
 	margin-bottom:		0;
 }
 
@@ -173,10 +174,7 @@ ol li::before{
 	padding:			0 !important;
 }
 
-.lwptoc_header{
-	font-family: 		"Poppins" !important;
-	font-size: 			2rem !important;
-    color: 				var( --gray-color ) !important;
+.lwptoc_header .lwptoc_title{
     margin: 			0 !important;
     padding: 			0 !important;
 }


### PR DESCRIPTION
* Add filter to set h5 instead of <div> <span> <b>
* Update styling