### PR TITLE
2020-09-22: 'Patient 0' bug-fix caused by a 0-index result in a falsify and therefore missing the first link highlighted

### DIFF
--- a/wp-content/themes/foxy-illdy/layout/js/tableOfContentActiveScroll.js
+++ b/wp-content/themes/foxy-illdy/layout/js/tableOfContentActiveScroll.js
@@ -58,7 +58,7 @@ $( document ).ready( function(){
 
 					// set next heading, when current is not the last one
 					let nextHeadingIndex = ( !currHeading || currHeading.index == headerArray.length - 1 ) ? undefined : currHeading.index + 1;
-					nextHeading = ( nextHeadingIndex ) ? getHeadingObj( nextHeadingIndex ) : undefined;
+					nextHeading = ( Number.isInteger( nextHeadingIndex ) ) ? getHeadingObj( nextHeadingIndex ) : undefined;
 				}
 			} else if( scrollPos < lastScrollPos ){
 				while( currHeading && scrollPos <= currHeading.offset ){
@@ -68,7 +68,7 @@ $( document ).ready( function(){
 					
 					// set next heading, when current is not the last one
 					let prevHeadingIndex = ( !currHeading || currHeading.index == 0 ) ? undefined : currHeading.index - 1;
-					prevHeading = ( prevHeadingIndex ) ? getHeadingObj( prevHeadingIndex ) : undefined;
+					prevHeading = ( Number.isInteger( prevHeadingIndex ) ) ? getHeadingObj( prevHeadingIndex ) : undefined;
 				}
 			}
 			


### PR DESCRIPTION
* Using Number.isInteger to make sure prevHeadinIndex == 0 to result in a true and therefore setting the first Heading as prevHeading